### PR TITLE
Fix: Correctly obtain platform

### DIFF
--- a/animecards_v35_modified.lua
+++ b/animecards_v35_modified.lua
@@ -57,14 +57,9 @@ local use_powershell_clipboard = nil
 if unpack ~= nil then table.unpack = unpack end
 
 local o = {}
-local platform
-if mp.get_property_native('options/vo-mmcss-profile', o) ~= o then
-  platform = 'windows'
-elseif mp.get_property('options/cocoa-force-dedicated-gpu', o) ~= o then
-  platform = 'macos'
-else
-  platform = 'linux'
-end
+local platform = mp.get_property_native("platform")
+if platform == "darwin" then
+  platform = "macos"
 
 local display_server
 if os.getenv("WAYLAND_DISPLAY") ~= "" then

--- a/animecards_v35_modified.lua
+++ b/animecards_v35_modified.lua
@@ -60,6 +60,7 @@ local o = {}
 local platform = mp.get_property_native("platform")
 if platform == "darwin" then
   platform = "macos"
+end
 
 local display_server
 if os.getenv("WAYLAND_DISPLAY") ~= "" then
@@ -75,6 +76,9 @@ local function dlog(...)
     print(...)
   end
 end
+
+dlog("Detected Platform: " .. platform)
+dlog("Detected display server: " .. display_server)
 
 local function anki_connect(action, params)
   local request


### PR DESCRIPTION
The current way of getting the platform is unreliable. On my machine, platform is set to linux when it should be macos, effectively breaking the script. This should be a better way.