### PR TITLE
Feature: Open anki browser after card update & Fix: Updating selected card

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Notable changes so far:
     - **Subtitle functionality is still used to determine what subtitle lines to use in the Anki card. It may make sense to replace clipboard functionality with a small platform independent subtitle selection menu.**
 - The default card fields conform with the Lapis note type by default. If you use [Lapis](https://github.com/donkuri/lapis) or [my fork](https://github.com/friedrich-de/lapis-modified) **(RECOMMENDED)** of it, this script should require zero configuration.
 - Added support for Wayland clipboard; Thanks to @kayprish
+- Added functionality to open the card browser after adding media and fixed the bug where notes would fail to update when selected in the card browser; Thanks to @adxria
 
 
 I'm not proficient in Lua. It would be great if someone took over or helped with this project providing LTS.


### PR DESCRIPTION
### What
This PR adds and option to open the Anki browser after updating a card and fixes a problem where the script fails to update a card that is currently selected in the browser.

### Why
Currently, the script doesn't allow users to automatically open the browser after updating a card.
Additionally, if the card is selected (focused) in the Anki browser, the update fails.

### How
- Added ALWAYS_OPEN_BROWSER which is not true by default
- Detect when a single note is selected (multiple selection doesn't cause the issue) and matches the note being updated
- Temporarily set the browser query to an invalid note ID to unfocus the card before updating
- After the update reselect the card if:
  - If the card was previously focused, or
  - If ALWAYS_OPEN_BROWSER is true

### Note
I'm only beginner in the coding and this is my first pull request. I'm sincerely apologize if I made any mistakes. Please let me know if there's anything I should improve