### PR TITLE
Fix "input not found" issue

### DIFF
--- a/animecards_v35_modified.lua
+++ b/animecards_v35_modified.lua
@@ -28,7 +28,7 @@
 
 local utils = require 'mp.utils'
 local msg = require 'mp.msg'
-local input = require 'mp.input'
+local is_input_exists, input = pcall(require, 'mp.input')
 
 ------------- User Config -------------
 -- Set these to match your field names in Anki
@@ -109,7 +109,7 @@ local function dlog(...)
   end
 end
 
-local function verfiy_libmp3lame()
+local function verify_libmp3lame()
   local encoderlist = mp.get_property("encoder-list")
   if not encoderlist or not string.find(encoderlist, "libmp3lame") then
     mp.osd_message(
@@ -121,7 +121,7 @@ local function verfiy_libmp3lame()
   end
 end
 
-mp.register_event("file-loaded", verfiy_libmp3lame)
+mp.register_event("file-loaded", verify_libmp3lame)
 
 dlog("Detected Platform: " .. platform)
 dlog("Detected display server: " .. display_server)
@@ -505,6 +505,14 @@ local function overwrite_cards(selected_notes, fields)
 end
 
 local function prompt_overwrite(fields)
+  if is_input_exists ~= true or type(input) ~= 'table' or type(input.select) ~= "function" then
+    mp.osd_message(
+      "Error: input.select not found. Cannot ask for overwrite confirmation.\nYour MPV version may be below 0.39?",
+      10)
+    msg.error("Error: input.select not found. Cannot ask for overwrite confirmation.")
+    return
+  end
+  
   local selected_notes = anki_connect("guiSelectedNotes")["result"]
 
   if #selected_notes == 0 then
@@ -519,14 +527,6 @@ local function prompt_overwrite(fields)
 
   if ASK_TO_OVERWRITE ~= true then
     overwrite_cards(selected_notes, fields)
-    return
-  end
-
-  if input.select == nil then
-    mp.osd_message(
-      "Error: input.select not found. Cannot ask for overwrite confirmation.\nYour MPV version may be below 0.39?",
-      10)
-    msg.error("Error: input.select not found. Cannot ask for overwrite confirmation.")
     return
   end
 


### PR DESCRIPTION
Fix error when requiring input and improve safety checks in prompt_overwrite()
--

Changes:
- Wrapped `require('input')` in `pcall` to handle missing modules
- Changed the `if` block in `prompt_overwrite()`
  1. First checks `pcall` status
  2. Verifies that input exists and is a table
  3. Then ensures `input.select` is exists and is a function
- Fixed a typo