### PR TITLE
Fix/windows latency

### DIFF
--- a/animecards/anki.lua
+++ b/animecards/anki.lua
@@ -8,7 +8,8 @@ local media_dir = ""
 
 function anki.request(action, params)
   local request = utils.format_json({ action = action, params = params, version = 6 })
-  local args = { 'curl', '-s', 'localhost:8765', '-X', 'POST', '-d', request }
+  -- Avoid "localhost" on Windows, it causes latency. Use 127.0.0.1 instead
+  local args = { 'curl', '-s', '127.0.0.1:8765', '-X', 'POST', '-d', request }
 
   tools.dlog("AnkiConnect request: " .. request)
 

--- a/animecards/card_builder.lua
+++ b/animecards/card_builder.lua
@@ -22,7 +22,7 @@ local function generate_miscinfo(start_time)
 end
 
 local function format_sentence(lines, noteid)
-  local mpv_sentence = string.gsub(string.gsub(lines, '\n+', '<br>'), '\r', '')
+  local mpv_sentence = lines:gsub('^\n+', ''):gsub('\n+$', ''):gsub('\r', ''):gsub('\n+', '<br>')
 
   if opts.HIGHLIGHT_WORD ~= true then
     return mpv_sentence

--- a/animecards/card_builder.lua
+++ b/animecards/card_builder.lua
@@ -22,7 +22,7 @@ local function generate_miscinfo(start_time)
 end
 
 local function format_sentence(lines, noteid)
-  local mpv_sentence = lines:gsub('^\n+', ''):gsub('\n+$', ''):gsub('\r', ''):gsub('\n+', '<br>')
+  local mpv_sentence = lines:gsub('\r', ''):gsub('^\n+', ''):gsub('\n+$', ''):gsub('\n+', '<br>')
 
   if opts.HIGHLIGHT_WORD ~= true then
     return mpv_sentence

--- a/animecards/clipboard.lua
+++ b/animecards/clipboard.lua
@@ -1,5 +1,6 @@
 local utils = require 'mp.utils'
 
+local opts = require 'script_options'
 local tools = require 'tools'
 
 local clipboard = {}
@@ -27,6 +28,11 @@ function clipboard.detect_platform()
 end
 
 function clipboard.read()
+  if opts.USE_MPV_CLIPBOARD_API == true then
+    local api_response = mp.get_property_native('clipboard/text')
+    return api_response
+  end
+
   local res
 
   if platform == 'windows' then
@@ -78,6 +84,11 @@ function clipboard.set(text)
   -- This way pressing control+v without copying from texthooker page
   -- will always give last line.
   text = string.gsub(text, "[\n\r]+", " ")
+
+  if opts.USE_MPV_CLIPBOARD_API == true then
+    mp.set_property("clipboard/text", text)
+    return
+  end
 
   if platform == 'windows' then
     -- Windows clipboard handling with automatic type detection

--- a/animecards/main.lua
+++ b/animecards/main.lua
@@ -52,6 +52,13 @@ local function process_cards(note_ids)
 
   -- Defines subs range from clipboard content
   local lines = clip.read()
+
+  if lines == nil then
+    mp.osd_message('Failed to access clipboard', 5)
+    msg.error('Failed to access clipboard: the value is nil.')
+    return
+  end
+
   local range_start, range_end = sub_obs.specify_range(lines)
 
   if range_start == nil and range_end == nil then

--- a/animecards/script_options.lua
+++ b/animecards/script_options.lua
@@ -14,6 +14,7 @@ opts.ENABLE_SUBS_TO_CLIP = false
 opts.ASK_TO_OVERWRITE = true
 opts.OVERWRITE_LIMIT = 8 -- negative 1 turns off the Limit
 opts.HIGHLIGHT_WORD = false
+opts.USE_MPV_CLIPBOARD_API = false
 
 -- Audio settings
 opts.AUDIO_CLIP_FADE = 0.2     -- seconds

--- a/script-opts/animecards.conf
+++ b/script-opts/animecards.conf
@@ -30,6 +30,11 @@ OVERWRITE_LIMIT=8
 # Keep bold formatting added by yomitan? (yes/no)
 HIGHLIGHT_WORD=no
 
+# Use MPV's built-in clipboard API (requires v0.40+)? (yes/no)
+# Alternative clipboard method that may reduce latency on Windows.
+# Supported on macOS and Wayland as well. Not supported on X11.
+USE_MPV_CLIPBOARD_API=no
+
 # ==========================================================
 # Audio Settings
 # ==========================================================


### PR DESCRIPTION
# Curl delay
As I understand it, Windows first tries to resolve localhost to an IPv6 address, and if nothing is listening there, it falls back to IPv4 (127.0.0.1), which causes a delay. With multiple calls to AnkiConnect, the latency inevitably adds up.

https://github.com/user-attachments/assets/fd0acb67-926a-4c5e-be5e-b5bdbaa83eb2

# Clipboard delay
Also, on Windows, there is noticeable latency related to the clipboard functionality in the script. I suspect that invoking PowerShell is the main issue.

![image](https://github.com/user-attachments/assets/a0195387-dc0d-4f05-bbc2-7ec75662d412)
_Clipboard response time (my machine)_

![photo_2025-07-05_21-25-35](https://github.com/user-attachments/assets/c7923009-950b-4d8b-aa24-c9b04d89f41a)
_Clipboard response time on friend's machine)_

I implemented support for MPV’s native clipboard API, but since it’s a relatively new feature, I chose to retain the original PowerShell-based approach and made the new method optional.

# Comparison
![2025-07-05_22-17-47_a2Njo6Ux](https://github.com/user-attachments/assets/623670f6-bea2-41b4-8df6-f9e51dd5d7ab)
_Before_

---

![2025-07-05_22-19-15_lgSvq9NC](https://github.com/user-attachments/assets/686338a5-7f97-4676-b7c5-56bba37d0a27)
_After_